### PR TITLE
Implement initial scaffold with Nest auth

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "node": true,
+    "es2020": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "rules": {}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.env
+.DS_Store
+npm-debug.log
+pnpm-lock.yaml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+{"singleQuote": true, "trailingComma": "all"}

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=upwork
+DB_PASS=upwork
+DB_NAME=upwork

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,3 @@
+# API
+
+NestJS backend placeholder.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "api",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "node dist/index.js",
+    "migration:run": "ts-node ./src/migration-runner.ts"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "pg": "^8.11.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.1",
+    "typeorm": "^0.3.17"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.13",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.4.0"
+  }
+}

--- a/apps/api/src/api-keys/api-keys.controller.ts
+++ b/apps/api/src/api-keys/api-keys.controller.ts
@@ -1,0 +1,17 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { ApiKeysService } from './api-keys.service';
+
+@Controller('api-keys')
+export class ApiKeysController {
+  constructor(private service: ApiKeysService) {}
+
+  @Get(':userId')
+  async list(@Param('userId') userId: string) {
+    return this.service.findAll(userId);
+  }
+
+  @Post(':userId')
+  async create(@Param('userId') userId: string, @Body() body: any) {
+    return this.service.create(userId, body);
+  }
+}

--- a/apps/api/src/api-keys/api-keys.module.ts
+++ b/apps/api/src/api-keys/api-keys.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ApiKey } from '../entities/api-key.entity';
+import { ApiKeysService } from './api-keys.service';
+import { ApiKeysController } from './api-keys.controller';
+import { User } from '../entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ApiKey, User])],
+  providers: [ApiKeysService],
+  controllers: [ApiKeysController],
+})
+export class ApiKeysModule {}

--- a/apps/api/src/api-keys/api-keys.service.ts
+++ b/apps/api/src/api-keys/api-keys.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ApiKey } from '../entities/api-key.entity';
+import { User } from '../entities/user.entity';
+
+@Injectable()
+export class ApiKeysService {
+  constructor(
+    @InjectRepository(ApiKey)
+    private keys: Repository<ApiKey>,
+    @InjectRepository(User)
+    private users: Repository<User>,
+  ) {}
+
+  async findAll(userId: string) {
+    return this.keys.find({ where: { user: { id: userId } } });
+  }
+
+  async create(userId: string, data: Partial<ApiKey>) {
+    const user = await this.users.findOneBy({ id: userId });
+    if (!user) return null;
+    const key = this.keys.create({ ...data, user });
+    return this.keys.save(key);
+  }
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from './auth/auth.module';
+import { ApiKeysModule } from './api-keys/api-keys.module';
+import { User } from './entities/user.entity';
+import { ApiKey } from './entities/api-key.entity';
+import { MeController } from './controllers/me.controller';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || '5432'),
+      username: process.env.DB_USER || 'upwork',
+      password: process.env.DB_PASS || 'upwork',
+      database: process.env.DB_NAME || 'upwork',
+      entities: [User, ApiKey],
+      synchronize: false,
+    }),
+    AuthModule,
+    ApiKeysModule,
+  ],
+  controllers: [MeController],
+})
+export class AppModule {}

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, Get, Post, Request, UseGuards } from '@nestjs/common';
+import { AuthService } from './auth.service';
+
+@Controller('auth')
+export class AuthController {
+  constructor(private auth: AuthService) {}
+
+  @Post('signup')
+  async signup(@Body() body: { email: string; password: string }) {
+    return this.auth.signup(body.email, body.password);
+  }
+
+  @Post('login')
+  async login(@Body() body: { email: string; password: string }) {
+    const user = await this.auth.validateUser(body.email, body.password);
+    if (!user) {
+      return { error: 'invalid credentials' };
+    }
+    return this.auth.login(user);
+  }
+}

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { User } from '../entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  providers: [AuthService],
+  controllers: [AuthController],
+})
+export class AuthModule {}

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { User } from '../entities/user.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import * as bcrypt from 'bcryptjs';
+import * as jwt from 'jsonwebtoken';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    @InjectRepository(User)
+    private users: Repository<User>,
+  ) {}
+
+  async signup(email: string, password: string) {
+    const hashedPw = await bcrypt.hash(password, 10);
+    const user = this.users.create({ email, hashedPw });
+    await this.users.save(user);
+    return { id: user.id, email: user.email };
+  }
+
+  async validateUser(email: string, password: string) {
+    const user = await this.users.findOne({ where: { email } });
+    if (!user) return null;
+    const match = await bcrypt.compare(password, user.hashedPw);
+    if (!match) return null;
+    return user;
+  }
+
+  async login(user: User) {
+    const payload = { sub: user.id, email: user.email };
+    const token = jwt.sign(payload, process.env.JWT_SECRET || 'secret');
+    return { access_token: token };
+  }
+}

--- a/apps/api/src/auth/jwt-auth.guard.ts
+++ b/apps/api/src/auth/jwt-auth.guard.ts
@@ -1,0 +1,19 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import * as jwt from 'jsonwebtoken';
+
+@Injectable()
+export class JwtAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const auth = request.headers['authorization'];
+    if (!auth) return false;
+    const token = auth.split(' ')[1];
+    try {
+      const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret') as any;
+      request.user = decoded;
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/apps/api/src/controllers/me.controller.ts
+++ b/apps/api/src/controllers/me.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AuthService } from '../auth/auth.service';
+
+@Controller()
+export class MeController {
+  constructor(private auth: AuthService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Get('me')
+  me(@Req() req: any) {
+    return req.user;
+  }
+}

--- a/apps/api/src/data-source.ts
+++ b/apps/api/src/data-source.ts
@@ -1,0 +1,15 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import { User } from './entities/user.entity';
+import { ApiKey } from './entities/api-key.entity';
+
+export const AppDataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.DB_HOST || 'localhost',
+  port: parseInt(process.env.DB_PORT || '5432'),
+  username: process.env.DB_USER || 'upwork',
+  password: process.env.DB_PASS || 'upwork',
+  database: process.env.DB_NAME || 'upwork',
+  entities: [User, ApiKey],
+  migrations: ['src/migrations/*.ts'],
+});

--- a/apps/api/src/entities/api-key.entity.ts
+++ b/apps/api/src/entities/api-key.entity.ts
@@ -1,0 +1,26 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne } from 'typeorm';
+import { User } from './user.entity';
+
+@Entity()
+export class ApiKey {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => User, (user) => user.apiKeys, { onDelete: 'CASCADE' })
+  user!: User;
+
+  @Column()
+  upworkKey!: string;
+
+  @Column()
+  upworkSecret!: string;
+
+  @Column({ nullable: true })
+  refreshToken!: string;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  expiresAt!: Date;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/apps/api/src/entities/user.entity.ts
+++ b/apps/api/src/entities/user.entity.ts
@@ -1,0 +1,29 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, OneToMany } from 'typeorm';
+import { ApiKey } from './api-key.entity';
+
+export enum UserRole {
+  OWNER = 'OWNER',
+  SDR = 'SDR',
+  VIEWER = 'VIEWER',
+}
+
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ unique: true })
+  email!: string;
+
+  @Column({ type: 'enum', enum: UserRole, default: UserRole.OWNER })
+  role!: UserRole;
+
+  @Column()
+  hashedPw!: string;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @OneToMany(() => ApiKey, (key) => key.user)
+  apiKeys!: ApiKey[];
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/apps/api/src/migration-runner.ts
+++ b/apps/api/src/migration-runner.ts
@@ -1,0 +1,12 @@
+import { AppDataSource } from './data-source';
+
+AppDataSource.initialize()
+  .then(() => AppDataSource.runMigrations())
+  .then(() => {
+    console.log('Migrations executed');
+    return AppDataSource.destroy();
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/apps/api/src/migrations/0001-init.ts
+++ b/apps/api/src/migrations/0001-init.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Init0001 implements MigrationInterface {
+  name = 'Init0001';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    // empty initial migration
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    // empty
+  }
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2019",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,3 @@
+# Web
+
+Next.js 14 dashboard placeholder.

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -1,0 +1,3 @@
+# Worker
+
+Polling worker placeholder.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:16
+    restart: always
+    environment:
+      POSTGRES_USER: upwork
+      POSTGRES_PASSWORD: upwork
+      POSTGRES_DB: upwork
+    ports:
+      - '5432:5432'
+    volumes:
+      - db-data:/var/lib/postgresql/data
+volumes:
+  db-data:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "upwork-autoresponder",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "prettier": "^3.2.5"
+  }
+}

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,0 +1,3 @@
+# Common
+
+Shared DTOs and utils placeholder.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {}
+  }
+}


### PR DESCRIPTION
## Summary
- set up pnpm workspaces and Turborepo skeleton
- add Postgres docker-compose and basic TypeORM setup
- add NestJS auth and API keys modules with simple JWT login

## Testing
- `pnpm --filter api run migration:run` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6874926f04c8832ca5c994172f05282e