### PR TITLE
Add startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,16 @@ This spec should give Codex (or any engineer) enough clarity to scaffold reposit
 
 ## Development
 
+For a single-command setup execute:
+
+```bash
+./scripts/start_all.sh
+```
+
+The script installs dependencies, starts supporting services, builds the API and runs the poller worker together with the API server.
+
+Manual steps if you prefer running each piece separately:
+
 1. Run `./scripts/bootstrap.sh` to install dependencies, start services and run migrations.
 2. Launch the API server: `node dist/index.js` after `pnpm --filter api run build`.
 3. Workers can be run locally via `pnpm poller:dev` or `pnpm draft:dev`.

--- a/scripts/start_all.sh
+++ b/scripts/start_all.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+# Start full stack locally
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(dirname "$DIR")"
+cd "$ROOT"
+
+# bootstrap dependencies
+"$DIR"/bootstrap.sh
+
+# build API once
+pnpm --filter api run build
+
+# start API and worker in background
+node apps/api/dist/index.js &
+API_PID=$!
+pnpm poller:dev &
+WORKER_PID=$!
+
+trap 'kill $API_PID $WORKER_PID' EXIT
+wait


### PR DESCRIPTION
## Summary
- add `start_all.sh` helper to launch API and worker after bootstrapping
- document quick start in README

## Testing
- `pnpm lint` *(fails: Parsing errors)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687632e5a818832cbd25b5e9c8e663bf