### PR TITLE
Improve startup script instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,19 @@ This spec should give Codex (or any engineer) enough clarity to scaffold reposit
 
 ## Development
 
+For a single-command setup execute:
+
+```bash
+./scripts/start_all.sh
+```
+
+This requires Docker with Docker Compose running and `pnpm` installed globally.
+The helper script installs dependencies, launches Postgres and observability
+containers, builds the API and runs the poller worker together with the API
+server. Stop both processes with `Ctrl+C`.
+
+Manual steps if you prefer running each piece separately:
+
 1. Run `./scripts/bootstrap.sh` to install dependencies, start services and run migrations.
 2. Launch the API server: `node dist/index.js` after `pnpm --filter api run build`.
 3. Workers can be run locally via `pnpm poller:dev` or `pnpm draft:dev`.

--- a/scripts/start_all.sh
+++ b/scripts/start_all.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+# Start full stack locally
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(dirname "$DIR")"
+cd "$ROOT"
+
+# Ensure Docker daemon is running
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker daemon is not running. Please start Docker and retry." >&2
+  exit 1
+fi
+
+# Ensure pnpm exists
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "pnpm not found. Install pnpm before running." >&2
+  exit 1
+fi
+
+# bootstrap dependencies
+"$DIR"/bootstrap.sh
+
+# build API once
+pnpm --filter api run build
+
+# start API and worker in background
+node apps/api/dist/index.js &
+API_PID=$!
+pnpm poller:dev &
+WORKER_PID=$!
+
+trap 'kill $API_PID $WORKER_PID' EXIT
+wait


### PR DESCRIPTION
## Summary
- check for Docker daemon and pnpm in `start_all.sh`
- document prerequisites for the single-command setup

## Testing
- `pnpm lint` *(fails: Parsing errors)*
- `pnpm test`
- `./scripts/start_all.sh` *(fails: Docker daemon not running)*

------
https://chatgpt.com/codex/tasks/task_e_687632e5a818832cbd25b5e9c8e663bf