### PR TITLE
Improve startup script instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,25 @@ This spec should give Codex (or any engineer) enough clarity to scaffold reposit
 
 ## Development
 
+### Requirements
+
+- Docker with Docker Compose installed.
+- Node.js 18+ and `pnpm` available globally (`npm install -g pnpm`).
+- On macOS the helper script tries to start Docker Desktop automatically if the daemon isn't running.
+
+For a single-command setup execute:
+
+```bash
+./scripts/start_all.sh
+```
+
+The helper script installs dependencies, launches Postgres and observability
+containers, builds the API and runs the poller worker together with the API
+server. On macOS Docker Desktop is started automatically if needed. Stop both
+processes with `Ctrl+C`.
+
+Manual steps if you prefer running each piece separately:
+
 1. Run `./scripts/bootstrap.sh` to install dependencies, start services and run migrations.
 2. Launch the API server: `node dist/index.js` after `pnpm --filter api run build`.
 3. Workers can be run locally via `pnpm poller:dev` or `pnpm draft:dev`.

--- a/scripts/start_all.sh
+++ b/scripts/start_all.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -e
+# Start full stack locally
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(dirname "$DIR")"
+cd "$ROOT"
+
+# Ensure Docker CLI exists
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is not installed. Follow https://docs.docker.com/get-docker/" >&2
+  exit 1
+fi
+
+# Start Docker if it is not running
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker daemon is not running." >&2
+  if [[ "$(uname)" == "Darwin" ]] && command -v open >/dev/null 2>&1; then
+    echo "Attempting to start Docker Desktop..." >&2
+    open -a Docker >/dev/null 2>&1 || true
+    until docker info >/dev/null 2>&1; do
+      printf '.'
+      sleep 2
+    done
+    echo
+  elif command -v systemctl >/dev/null 2>&1; then
+    echo "Trying to start docker service..." >&2
+    sudo systemctl start docker || true
+    until docker info >/dev/null 2>&1; do
+      sleep 2
+    done
+  else
+    echo "Please start Docker manually and retry." >&2
+    exit 1
+  fi
+fi
+
+# Ensure pnpm exists
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "pnpm not found. Install pnpm before running." >&2
+  exit 1
+fi
+
+# bootstrap dependencies
+"$DIR"/bootstrap.sh
+
+# build API once
+pnpm --filter api run build
+
+# start API and worker in background
+node apps/api/dist/index.js &
+API_PID=$!
+pnpm poller:dev &
+WORKER_PID=$!
+
+trap 'kill $API_PID $WORKER_PID' EXIT
+wait


### PR DESCRIPTION
## Summary
- check for Docker CLI and auto-start Docker Desktop
- add requirements section explaining the prerequisites

## Testing
- `pnpm lint` *(fails: Parsing errors)*
- `pnpm test`
- `./scripts/start_all.sh` *(fails: Docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687632e5a818832cbd25b5e9c8e663bf