### PR TITLE
Fix API build and type setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,25 @@ This spec should give Codex (or any engineer) enough clarity to scaffold reposit
 
 ## Development
 
+### Requirements
+
+- Docker with Docker Compose installed.
+- Node.js 18+ (the script installs `pnpm` globally if missing). Install from <https://nodejs.org/> or via nvm.
+- On macOS the helper script tries to start Docker Desktop automatically if the daemon isn't running.
+
+For a single-command setup execute:
+
+```bash
+./scripts/start_all.sh
+```
+
+The helper script installs dependencies, launches Postgres and observability
+containers, builds the API and runs the poller worker together with the API
+server. On macOS Docker Desktop is started automatically if needed. Stop both
+processes with `Ctrl+C`.
+
+Manual steps if you prefer running each piece separately:
+
 1. Run `./scripts/bootstrap.sh` to install dependencies, start services and run migrations.
 2. Launch the API server: `node dist/index.js` after `pnpm --filter api run build`.
 3. Workers can be run locally via `pnpm poller:dev` or `pnpm draft:dev`.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,12 +25,20 @@
     "pg": "^8.11.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
-    "typeorm": "^0.3.17"
+    "typeorm": "^0.3.17",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.2",
+    "express": "^4.18.2",
+    "body-parser": "^1.20.2"
   },
   "devDependencies": {
     "@types/node": "^24.0.13",
     "ts-node": "^10.9.1",
     "typescript": "^5.4.0",
-    "nock": "^13.5.4"
+    "nock": "^13.5.4",
+    "@types/bcryptjs": "^2.4.2",
+    "@types/jsonwebtoken": "^9.0.2",
+    "@types/express": "^4.17.21",
+    "@types/body-parser": "^1.19.2"
   }
 }

--- a/apps/api/src/proposals/proposals.controller.ts
+++ b/apps/api/src/proposals/proposals.controller.ts
@@ -1,6 +1,7 @@
 
 import { Body, Controller, Param, Post, UseGuards, Req, BadRequestException } from '@nestjs/common';
 import { Get, Query } from '@nestjs/common';
+import { Request } from 'express';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { ProposalsService } from './proposals.service';
 import { ProposalFeedback } from '../entities/proposal.entity';
@@ -15,7 +16,7 @@ export class ProposalsController {
 
   @Get()
   @UseGuards(JwtAuthGuard)
-  list(@Query('status') status: string, @Req() req) {
+  list(@Query('status') status: string, @Req() req: Request) {
     return this.service.listForUser(req.user.id, status as any);
   }
 
@@ -30,7 +31,7 @@ export class ProposalsController {
 
   @Post(':id/send')
   @UseGuards(JwtAuthGuard)
-  async send(@Param('id') id: string, @Req() req) {
+  async send(@Param('id') id: string, @Req() req: Request) {
     const prop = await this.service.findOwned(id, req.user.id);
     if (!prop) throw new BadRequestException('Not found');
     if (prop.status !== 'DRAFT')

--- a/apps/api/src/tenant/tenant.subscriber.ts
+++ b/apps/api/src/tenant/tenant.subscriber.ts
@@ -7,6 +7,10 @@ export class TenantSubscriber implements EntitySubscriberInterface {
     dataSource.subscribers.push(this);
   }
 
+  listenTo() {
+    return Object;
+  }
+
   beforeFind(event: any) {
     const store = tenantStorage.getStore();
     const userId = store?.userId;

--- a/apps/api/src/types/cron.d.ts
+++ b/apps/api/src/types/cron.d.ts
@@ -1,0 +1,1 @@
+declare module 'cron';

--- a/apps/api/src/types/express.d.ts
+++ b/apps/api/src/types/express.d.ts
@@ -1,0 +1,6 @@
+import 'express';
+declare module 'express' {
+  interface Request {
+    user?: any;
+  }
+}

--- a/apps/api/src/types/json-logic-js.d.ts
+++ b/apps/api/src/types/json-logic-js.d.ts
@@ -1,0 +1,1 @@
+declare module 'json-logic-js';

--- a/apps/api/src/upwork-auth/upwork-auth.module.ts
+++ b/apps/api/src/upwork-auth/upwork-auth.module.ts
@@ -7,7 +7,7 @@ import { UpworkAuthController } from './upwork-auth.controller';
 import { ApiKey } from '../entities/api-key.entity';
 
 @Module({
-  imports: [HttpModule, ScheduleModule.forFeature(), TypeOrmModule.forFeature([ApiKey])],
+  imports: [HttpModule, ScheduleModule.forRoot(), TypeOrmModule.forFeature([ApiKey])],
   providers: [UpworkAuthService],
   controllers: [UpworkAuthController],
   exports: [UpworkAuthService],

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -7,8 +7,10 @@
     "strict": true,
     "esModuleInterop": true,
     "emitDecoratorMetadata": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "types": ["node"],
+    "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "smoke": "TS_NODE_PROJECT=tests/tsconfig.json ts-node tests/smoke/simulateJobs.spec.ts"
   },
   "devDependencies": {
+    "@aws-sdk/client-sqs": "^3.521.0",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
-    "ts-node-dev": "^2.0.0",
     "ts-node": "^10.9.1",
-    "@aws-sdk/client-sqs": "^3.521.0"
+    "ts-node-dev": "^2.0.0"
   }
 }

--- a/scripts/start_all.sh
+++ b/scripts/start_all.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+# fail if variables are undefined or a pipeline fails
+set -o pipefail
+set -u
+# Start full stack locally
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(dirname "$DIR")"
+cd "$ROOT"
+
+# Ensure Docker CLI exists
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is not installed. Follow https://docs.docker.com/get-docker/" >&2
+  exit 1
+fi
+
+# Start Docker if it is not running
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker daemon is not running." >&2
+  if [[ "$(uname)" == "Darwin" ]] && command -v open >/dev/null 2>&1; then
+    echo "Attempting to start Docker Desktop..." >&2
+    open -a Docker >/dev/null 2>&1 || true
+    until docker info >/dev/null 2>&1; do
+      printf '.'
+      sleep 2
+    done
+    echo
+  elif command -v systemctl >/dev/null 2>&1; then
+    echo "Trying to start docker service..." >&2
+    sudo systemctl start docker || true
+    until docker info >/dev/null 2>&1; do
+      sleep 2
+    done
+  else
+    echo "Please start Docker manually and retry." >&2
+    exit 1
+  fi
+fi
+
+# Ensure Node.js is available
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js is not installed. Install Node.js 18+ first: https://nodejs.org" >&2
+  exit 1
+fi
+
+# Ensure pnpm exists
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "pnpm not found. Installing globally..." >&2
+  if command -v npm >/dev/null 2>&1; then
+    npm install -g pnpm >/dev/null 2>&1
+  else
+    echo "npm is not installed. Please install Node.js first." >&2
+    exit 1
+  fi
+fi
+
+# bootstrap dependencies
+"$DIR"/bootstrap.sh
+
+# build API once
+pnpm --filter api run build
+
+# start API and worker in background
+node apps/api/dist/index.js &
+API_PID=$!
+pnpm poller:dev &
+WORKER_PID=$!
+
+trap 'kill $API_PID $WORKER_PID' EXIT
+wait


### PR DESCRIPTION
## Summary
- declare custom Express and cron types
- add missing dependencies for API build
- disable library type checking

## Testing
- `pnpm lint` *(fails: 101 parsing errors)*
- `pnpm test`
- `pnpm --filter api run build`
- `./scripts/start_all.sh` *(fails: Docker is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687632e5a818832cbd25b5e9c8e663bf