### PR TITLE
Fix worker tsconfig

### DIFF
--- a/apps/worker/src/poller.ts
+++ b/apps/worker/src/poller.ts
@@ -1,9 +1,11 @@
 /* tracing.ts пока необязателен; заглушка, чтобы не падать */
-try {
-  await import('./tracing');
-} catch {
-  /* noop */
-}
+(async () => {
+  try {
+    await import('./tracing');
+  } catch {
+    /* noop */
+  }
+})();
 import 'reflect-metadata';
 import { DataSource } from 'typeorm';
 /* ApiKey entity объявлен в API-приложении.

--- a/apps/worker/src/types/json-logic-js.d.ts
+++ b/apps/worker/src/types/json-logic-js.d.ts
@@ -1,0 +1,1 @@
+declare module 'json-logic-js';

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -3,10 +3,12 @@
     "module": "commonjs",
     "target": "es2019",
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": "..",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "../api/src/entities/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- include API entity files for worker build
- enable decorators for worker compilation
- handle optional tracing import without top-level await
- add type declaration for json-logic-js

## Testing
- `pnpm --filter api run build`
- `pnpm --filter worker run build`


------
https://chatgpt.com/codex/tasks/task_e_687a128d76a4832ca687d2d84244bf7f