### PR TITLE
Fix worker tsconfig

### DIFF
--- a/apps/worker/src/poller.ts
+++ b/apps/worker/src/poller.ts
@@ -1,11 +1,13 @@
 /* tracing.ts пока необязателен; заглушка, чтобы не падать */
-try {
-  await import('./tracing');
-} catch {
-  /* noop */
-}
+(async () => {
+  try {
+    await import('./tracing');
+  } catch {
+    /* noop */
+  }
+})();
 import 'reflect-metadata';
-import { DataSource } from 'typeorm';
+import { AppDataSource } from './data-source';
 /* ApiKey entity объявлен в API-приложении.
    В монорепо достаточно сослаться на исходный файл: */
 import { ApiKey } from '../../api/src/entities/api-key.entity';
@@ -15,15 +17,7 @@ import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs';
 import Redis from 'ioredis';
 import { log, error } from './logger';
 
-const dataSource = new DataSource({
-  type: 'postgres',
-  host: process.env.DB_HOST || 'localhost',
-  port: parseInt(process.env.DB_PORT || '5432'),
-  username: process.env.DB_USER || 'upwork',
-  password: process.env.DB_PASS || 'upwork',
-  database: process.env.DB_NAME || 'upwork',
-  entities: [ApiKey, User],
-});
+const dataSource = AppDataSource;
 
 const sqs = new SQSClient({});
 const redis = new Redis(process.env.REDIS_URL || 'redis://localhost:6379');

--- a/apps/worker/src/types/json-logic-js.d.ts
+++ b/apps/worker/src/types/json-logic-js.d.ts
@@ -1,0 +1,1 @@
+declare module 'json-logic-js';

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -3,10 +3,12 @@
     "module": "commonjs",
     "target": "es2019",
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": "..",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "../api/src/entities/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- include API entity files for worker build
- enable decorators for worker compilation
- handle optional tracing import without top-level await
- reuse AppDataSource in the poller
- add type declaration for json-logic-js

## Testing
- `pnpm --filter api run build`
- `pnpm --filter worker run build`


------
https://chatgpt.com/codex/tasks/task_e_687a128d76a4832ca687d2d84244bf7f